### PR TITLE
More fixes

### DIFF
--- a/main.py
+++ b/main.py
@@ -219,7 +219,7 @@ class IPATool(object):
         }
 
         if args.get_verid:
-            logger.info("Retriving verId using iTunes webpage...")
+            logger.info("Retrieving verId using iTunes webpage...")
             verId = iTunes.getAppVerId(self.appId, args.country)
             logger.info("Got current verId using iTunes webpage: %s" % verId)
             ret["appVerId"] = verId
@@ -321,7 +321,7 @@ class IPATool(object):
 
     def handlePurchase(self, args):
         Store = self._get_StoreClient(args)
-        logger.info('Try to purchasing appId %s' % (self.appId))
+        logger.info('Try to purchase appId %s' % (self.appId))
         try:
             Store.purchase(self.appId)
         except StoreException as e:
@@ -352,12 +352,12 @@ class IPATool(object):
                     self.appVerIds = cacheContent['appVerIds']
                     return
 
-        logger.info('Retriving history version for appId %s' % self.appId)
+        logger.info('Retrieving history version for appId %s' % self.appId)
 
         try:
             Store = self._get_StoreClient(args)
 
-            logger.info('Retriving download info for appId %s' % (self.appId))
+            logger.info('Retrieving download info for appId %s' % (self.appId))
             if args.purchase:
                 logger.info('Purchasing appId %s' % (self.appId))
                 # We have already successfully purchased, so don't purchase again :)
@@ -453,7 +453,7 @@ class IPATool(object):
             if args.purchase:
                 self.handlePurchase(args)
             
-            logger.info('Retriving download info for appId %s%s' % (self.appId, " with versionId %s" % self.appVerId if self.appVerId else ""))
+            logger.info('Retrieving download info for appId %s%s' % (self.appId, " with versionId %s" % self.appVerId if self.appVerId else ""))
 
             downResp = Store.download(self.appId, self.appVerId, isRedownload=not args.purchase)
             logger.debug('Got download info: %s', downResp.as_dict())

--- a/main.py
+++ b/main.py
@@ -60,7 +60,7 @@ def downloadFile(url, outfile, retries=10):
 
 download_sess = requests.Session()
 download_sess.headers = {"User-Agent": CONFIGURATOR_UA}
-DOWNLOAD_READ_TIMEOUT = 60.0
+DOWNLOAD_READ_TIMEOUT = 25.0
 def _downloadFile(url, outfile):
     with download_sess.get(url, stream=True, timeout=DOWNLOAD_READ_TIMEOUT) as r:
         if not r.headers.get('Content-Length'):
@@ -95,8 +95,13 @@ class IPATool(object):
 
         retry_strategy = Retry(
             connect=4,
-            read=2,
-            total=8,
+            read=4,
+            # total=8,
+            status=20,
+            allowed_methods=None,
+            status_forcelist=[429, 502, 503],
+            backoff_factor=1.0,
+            respect_retry_after_header=False,
         )
         self.sess.mount("https://", HTTPAdapter(max_retries=retry_strategy))
         self.sess.mount("http://", HTTPAdapter(max_retries=retry_strategy))

--- a/main.py
+++ b/main.py
@@ -549,7 +549,7 @@ class IPATool(object):
 
 def main():
     tool = IPATool()
-
     tool.tool_main()
 
-main()
+if __name__ == '__main__':
+    main()

--- a/main.py
+++ b/main.py
@@ -105,6 +105,13 @@ class IPATool(object):
         )
         self.sess.mount("https://", HTTPAdapter(max_retries=retry_strategy))
         self.sess.mount("http://", HTTPAdapter(max_retries=retry_strategy))
+        IPATOOL_PROXY = os.getenv("IPATOOL_PROXY")
+        if IPATOOL_PROXY is not None:
+            self.sess.proxies.update(
+                {'http': IPATOOL_PROXY, 'https': IPATOOL_PROXY})
+            # self.sess.headers = {}
+            self.sess.headers = {"Connection": "close"}
+            self.sess.keep_alive = False
 
         self.appId = None
         # self.appInfo = None

--- a/main.py
+++ b/main.py
@@ -270,9 +270,10 @@ class IPATool(object):
             session_cache = os.path.join(args.session_dir, args.appleid) if args.session_dir else None
             if session_cache and os.path.exists(session_cache):
                 needLogin = False
-                with open(session_cache, "r") as f:
-                    content = f.read()
                 try:
+                    # inside try in case the file format changed
+                    with open(session_cache, "r") as f:
+                        content = f.read()
                     Store.authenticate_load_session(content)
                 except Exception as e:
                     logger.warning(f"Error loading session {session_cache}")

--- a/main.py
+++ b/main.py
@@ -228,7 +228,7 @@ class IPATool(object):
 
     storeClientCache = {}
     def _get_StoreClient(self, args):
-        for k, v in self.storeClientCache:
+        for k, v in self.storeClientCache.items():
             if time.time() - v < 30.0:
                 return k
             else:
@@ -312,6 +312,7 @@ class IPATool(object):
             Store.sess.original_post = Store.sess.post
             Store.sess.post = authedPost
 
+        self.storeClientCache[Store] = time.time()
         return Store
 
     def _handleStoreException(self, _e):


### PR DESCRIPTION
* typos (retrieve)
* allow ipatool to run as an import library (__main__)
* use storeClientCache
* write meta.plist separately in case the downloaded file is not a zip file (e.g., macOS apps)
* cope with session file format changes