### PR TITLE
Added minimum OS version to search output

### DIFF
--- a/main.py
+++ b/main.py
@@ -207,7 +207,7 @@ class IPATool(object):
             logger.fatal("Failed to find app in country %s with %s" % (args.country, s))
             return
         appInfo = appInfos.results[0]
-        logger.info("Found app:\n\tName: %s\n\tVersion: %s\n\tbundleId: %s\n\tappId: %s" % (appInfo.trackName, appInfo.version, appInfo.bundleId, appInfo.trackId))
+        logger.info("Found app:\n\tName: %s\n\tVersion: %s\n\tbundleId: %s\n\tappId: %s\n\tminimumOsVersion: %s" % (appInfo.trackName, appInfo.version, appInfo.bundleId, appInfo.trackId, appInfo.minimumOsVersion))
         self.appId = appInfo.trackId
         # self.appInfo = appInfo
 


### PR DESCRIPTION
A simple PR that adds the Minimum OS Version to the logging output of a search. This is useful because I often need this information early on when doing an assessment.

![](https://i.imgur.com/XByAGck.png)