### PR TITLE
Improve in-memory cache

### DIFF
--- a/main.py
+++ b/main.py
@@ -228,11 +228,12 @@ class IPATool(object):
 
     storeClientCache = {}
     def _get_StoreClient(self, args):
-        for k, v in self.storeClientCache.items():
-            if time.time() - v < 30.0:
-                return k
-            else:
-                del self.storeClientCache[k]
+        cachekey = args.itunes_server or args.appleid
+        store, lastseen = self.storeClientCache.get(cachekey, (None, None,)) 
+        if store:
+            if time.time() - lastseen < 30.0:
+                return store
+            del self.storeClientCache[cachekey]
 
         newSess = pickle.loads(pickle.dumps(self.sess))
         Store = StoreClient(newSess)
@@ -313,7 +314,7 @@ class IPATool(object):
             Store.sess.original_post = Store.sess.post
             Store.sess.post = authedPost
 
-        self.storeClientCache[Store] = time.time()
+        self.storeClientCache[cachekey] = (Store, time.time(),)
         return Store
 
     def _handleStoreException(self, _e):


### PR DESCRIPTION
Improve in-memory cache by using the itunes_server or apple_id as the key; fixes #42